### PR TITLE
add minimum dependency-versions to requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 3bc047ad1c4522104023d4fbbfc9aceed14d316fdb16865a514f26b3e628b494
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
 
   rpaths:
@@ -25,28 +25,28 @@ build:
 requirements:
   build:
     - r-base
-    - r-r6
+    - r-r6 >=2.2.0
     - r-crayon
     - r-digest
     - r-magrittr
     - r-praise
     - r-cli
     - r-rlang
-    - r-withr
+    - r-withr >=2.0.0
     - posix                # [win]
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
 
   run:
     - r-base
-    - r-r6
+    - r-r6 >=2.2.0
     - r-crayon
     - r-digest
     - r-magrittr
     - r-praise
     - r-cli
     - r-rlang
-    - r-withr
+    - r-withr >=2.0.0
 
 test:
   commands:


### PR DESCRIPTION
`test_that` 2.0.0 has minimum requirements on the packages `withr` (>=2.0.0)
and `R6` (>=2.2.0) according to CRAN.

The minimum version numbers were added to the requirements-build and
requirements-run sections of meta.yaml

This should fix a runtime bug that occurred when I `conda install`ed
r-testthat into an environment that already had `r-withr` v1.0.2 installed.
The bug arose when loading `test_that` into R: the error `Error:
'local_options' is not an exported object from 'namespace:withr'` was thrown